### PR TITLE
Support for SPM in Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
   name: "WeakMapTable",
+  platforms: [
+    .macOS(.v10_11), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
+  ],
   products: [
     .library(name: "WeakMapTable", targets: ["WeakMapTable"]),
   ],


### PR DESCRIPTION
# What's happening

When I open Package.swift of ReactorKit in Xcode 12.0.1, I get the following build error.

> The package product 'WeakMapTable' requires minimum platform version 9.0 for the iOS platform, but this target supports 8.0

Probably iOS 8 was implicitly applied when omitting platforms in Xcode 11.x, but it seems that iOS 9 is applied from Xcode 12.x.

# Changes

Adding platforms to Package.swift in WeakMapTable fixed the issue.