### PR TITLE
Add removeAll() method to WeakMapTable

### DIFF
--- a/Sources/WeakMapTable/WeakMapTable.swift
+++ b/Sources/WeakMapTable/WeakMapTable.swift
@@ -68,6 +68,13 @@ final public class WeakMapTable<Key, Value> where Key: AnyObject {
     }
   }
 
+  public func removeAll() {
+    self.lock.lock()
+    defer {
+        self.lock.unlock()
+    }
+    self.dictionary.removeAll()
+  }
 
   // MARK: Getting and Setting Values without Locking
 

--- a/Tests/WeakMapTableTests/WeakMapTableTests.swift
+++ b/Tests/WeakMapTableTests/WeakMapTableTests.swift
@@ -81,6 +81,23 @@ final class WeakMapTableTests: XCTestCase {
     XCTAssertNil(weakKey)
     XCTAssertNil(weakValue)
   }
+
+  func testRemoveAll() {
+    let map = WeakMapTable<KeyObject, ValueObject>()
+    let key = KeyObject()
+    weak var weakValue: ValueObject?
+
+    _ = {
+      let value = ValueObject()
+      map.setValue(value, forKey: key)
+      weakValue = value
+
+      map.removeAll()
+    }()
+
+    XCTAssertNil(map.value(forKey: key))
+    XCTAssertNil(weakValue)
+  }
 }
 
 private final class KeyObject {


### PR DESCRIPTION
This PR adds a removeAll() method to WeakMapTable, allowing all key–value pairs to be removed in one call.
The method acquires the internal lock before clearing the underlying dictionary to ensure thread safety